### PR TITLE
Fix analysis set description field name to match JSON response

### DIFF
--- a/pkmn/index.test.ts
+++ b/pkmn/index.test.ts
@@ -59,6 +59,8 @@ describe('Smogon', () => {
         .toEqual([['Zen Mode']]);
       expect((await smogon.analyses(gen(3), 'Gengar', 'gen3ou' as ID))[0].overview)
         .toMatch('Gengar is a centralizing threat in ADV OU');
+      expect((await smogon.analyses(gen(3), 'Gengar', 'gen3ou' as ID))[0].sets[0].desc)
+        .toMatch('Defensive Gengar is most commonly used on teams that');
       const clefable = await smogon.analyses(gen(4), 'Clefable', 'gen4uu' as ID);
       expect(clefable[0].format).toBe('gen4uu');
       expect(clefable[0].sets[0].moves[0]).toEqual(['Ice Beam', 'Encore']);

--- a/pkmn/index.ts
+++ b/pkmn/index.ts
@@ -38,7 +38,7 @@ interface RawAnalysis {
   comments?: string;
   sets: Array<{
     name: string;
-    desc?: string;
+    description?: string;
   }>;
   credits?: Credits;
 }
@@ -252,7 +252,7 @@ export class Smogon {
         if (set && this.match(species, this.toSet(species, set))) {
           analysis.sets.push({
             name: stub.name,
-            desc: stub.desc,
+            desc: stub.description,
             ...set,
           } as Moveset & {name: string; desc?: string});
         }


### PR DESCRIPTION
There was a mismatch between the JSON fields from the pkmn.cc analysis sets and the code, expecting "desc" but was actually getting "description".