### PR TITLE
Add support for vgc2024regg

### DIFF
--- a/pkmn/index.test.ts
+++ b/pkmn/index.test.ts
@@ -249,5 +249,6 @@ describe('Smogon', () => {
     expect(baseFormat('gen8battlestadiumdoublesseries13')).toBe('gen8battlestadiumdoubles');
     expect(baseFormat('gen9vgc2023regulatione')).toBe('gen9vgc2023');
     expect(baseFormat('gen9vgc2024regf')).toBe('gen9vgc2024');
+    expect(baseFormat('gen9vgc2024regg')).toBe('gen9vgc2024');
   });
 });

--- a/update/sets.mjs
+++ b/update/sets.mjs
@@ -70,7 +70,7 @@ const FORMATS = {
   vgc11: 'vgc2011', vgc12: 'vgc2012', vgc14: 'vgc2014', vgc15: 'vgc2015', vgc16: 'vgc2016',
   vgc17: 'vgc2017', vgc18: 'vgc2018', vgc19: 'vgc2019', vgc20: 'vgc2020', vgc21: 'vgc2021',
   vgc22: 'vgc2022', vgc23series1: 'vgc2023', vgc23series2: 'vgc2023', vgc23series3: 'vgc2023',
-  vgc23series4: 'vgc2023', vgc24regulatione: 'vgc2023', vgc24regulationf: 'vgc2024',
+  vgc23series4: 'vgc2023', vgc24regulatione: 'vgc2023', vgc24regf: 'vgc2024', vgc24regg: 'vgc2024'
   vgc: 'vgc2024',
   // RBwhY?
   nintendocup1997: 'nc1997', nintendocup1998: 'nc1998', nintendocup1999: 'nc1999',

--- a/update/sets.mjs
+++ b/update/sets.mjs
@@ -70,7 +70,7 @@ const FORMATS = {
   vgc11: 'vgc2011', vgc12: 'vgc2012', vgc14: 'vgc2014', vgc15: 'vgc2015', vgc16: 'vgc2016',
   vgc17: 'vgc2017', vgc18: 'vgc2018', vgc19: 'vgc2019', vgc20: 'vgc2020', vgc21: 'vgc2021',
   vgc22: 'vgc2022', vgc23series1: 'vgc2023', vgc23series2: 'vgc2023', vgc23series3: 'vgc2023',
-  vgc23series4: 'vgc2023', vgc24regulatione: 'vgc2023', vgc24regf: 'vgc2024', vgc24regg: 'vgc2024'
+  vgc23series4: 'vgc2023', vgc24regulatione: 'vgc2023', vgc24regf: 'vgc2024', vgc24regg: 'vgc2024',
   vgc: 'vgc2024',
   // RBwhY?
   nintendocup1997: 'nc1997', nintendocup1998: 'nc1998', nintendocup1999: 'nc1999',

--- a/update/stats.mjs
+++ b/update/stats.mjs
@@ -40,7 +40,7 @@ const request = wrapr.retrying(wrapr.throttling(fetch, 5, 1000));
 const N = 1e4;
 
 const UNSUPPORTED = ['1v1', 'challengecup1vs1'];
-const SPECIAL = /(gen[789](?:vgc20(?:19|21|22|23)|battlestadium(?:singles|doubles)))(.*)/;
+const SPECIAL = /(gen[789](?:vgc20(?:19|21|22|23|24)|battlestadium(?:singles|doubles)))(.*)/;
 
 async function convert(format, date) {
   const leads = !stats.isNonSinglesFormat(format) && !UNSUPPORTED.includes(format);


### PR DESCRIPTION
Added mentions of regulationg where mentions of regulationf exist. This *should* work but please look it over to make sure and make changes where necessary as I haven't tested this yet.

Also changed one mention in `sets.mjs` of `vgc24regulationf` to be `vgc24regf`. This assumption might not be correct but it seemed consistent with other code. 
`gen9vgc2024.json` in `/data/sets/` already seems to include data for Pokémon that have only become legal in regulation G, i.e. Terapagos, so it's likely another format covers this already? But the same can be said for regulation F in the past, so I'm not sure what the correct approach here is.