### PR TITLE
Fix parsing with smogon.Analyses.request

### DIFF
--- a/smogon/index.ts
+++ b/smogon/index.ts
@@ -144,6 +144,9 @@ export const Analyses = new (class {
    * Parses out the DexSettings object embedded in the raw HTML retrieved from the Smogon dex.
    */
   parse(raw: string) {
+    try {
+      return JSON.parse(raw) as DexSettings;
+    } catch {}
     const match = PARSE_REGEX.exec(raw);
     if (!match) return undefined;
     return JSON.parse(match[1]) as DexSettings;


### PR DESCRIPTION
Since `smogon.Analyses.url` is deprecated, we should use `smogon.Analyses.request`, which returns a well-formatted JSON object that we need to process.